### PR TITLE
Add a protected hook to InputPage for subclass option controls

### DIFF
--- a/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
+++ b/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
@@ -113,11 +113,7 @@ public abstract class InputPage extends UserInputWizardPage {
 	}
 
 	/**
-	 * A hook for subclasses to add option controls to the page. Called by
-	 * {@link #createControl(Composite)} after the settings have been loaded and the
-	 * option composite has been created. The default implementation does nothing.
-	 * Subclasses override this to call {@link #addIntegerButton} /
-	 * {@link #addBooleanButton} on the given composite.
+	 * A hook for subclasses to add option controls to the page. Called by {@link #createControl(Composite)} after the settings have been loaded and the option composite has been created. The default implementation does nothing. Subclasses override this to call {@link #addIntegerButton} / {@link #addBooleanButton} on the given composite.
 	 *
 	 * @param optionComposite The composite to which option controls should be added.
 	 */

--- a/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
+++ b/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
@@ -113,7 +113,9 @@ public abstract class InputPage extends UserInputWizardPage {
 	}
 
 	/**
-	 * A hook for subclasses to add option controls to the page. Called by {@link #createControl(Composite)} after the settings have been loaded and the option composite has been created. The default implementation does nothing. Subclasses override this to call {@link #addIntegerButton}/{@link #addBooleanButton} on the given composite.
+	 * A hook for subclasses to add option controls to the page. Called by {@link #createControl(Composite)} after the settings have been
+	 * loaded and the option composite has been created. The default implementation does nothing. Subclasses override this to call
+	 * {@link #addIntegerButton}/{@link #addBooleanButton} on the given composite.
 	 *
 	 * @param optionComposite The composite to which option controls should be added.
 	 */

--- a/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
+++ b/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
@@ -113,7 +113,7 @@ public abstract class InputPage extends UserInputWizardPage {
 	}
 
 	/**
-	 * A hook for subclasses to add option controls to the page. Called by {@link #createControl(Composite)} after the settings have been loaded and the option composite has been created. The default implementation does nothing. Subclasses override this to call {@link #addIntegerButton} / {@link #addBooleanButton} on the given composite.
+	 * A hook for subclasses to add option controls to the page. Called by {@link #createControl(Composite)} after the settings have been loaded and the option composite has been created. The default implementation does nothing. Subclasses override this to call {@link #addIntegerButton}/{@link #addBooleanButton} on the given composite.
 	 *
 	 * @param optionComposite The composite to which option controls should be added.
 	 */

--- a/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
+++ b/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
@@ -30,6 +30,14 @@ public abstract class InputPage extends UserInputWizardPage {
 	}
 
 	protected void addBooleanButton(String text, final String key, final Consumer<Boolean> valueConsumer, Composite result) {
+		this.addBooleanButton(text, key, false, valueConsumer, result);
+	}
+
+	protected void addBooleanButton(String text, final String key, boolean defaultValue, final Consumer<Boolean> valueConsumer,
+			Composite result) {
+		if (this.settings.get(key) == null)
+			this.settings.put(key, defaultValue);
+
 		Button button = new Button(result, SWT.CHECK);
 		button.setText(text);
 		boolean value = this.settings.getBoolean(key);
@@ -46,6 +54,13 @@ public abstract class InputPage extends UserInputWizardPage {
 	}
 
 	protected void addIntegerButton(String text, String key, Consumer<Integer> valueConsumer, Composite result) {
+		this.addIntegerButton(text, key, 0, valueConsumer, result);
+	}
+
+	protected void addIntegerButton(String text, String key, int defaultValue, Consumer<Integer> valueConsumer, Composite result) {
+		if (this.settings.get(key) == null)
+			this.settings.put(key, defaultValue);
+
 		Label label = new Label(result, SWT.HORIZONTAL);
 		label.setText(text);
 
@@ -90,9 +105,24 @@ public abstract class InputPage extends UserInputWizardPage {
 
 		compositeForIntegerButton.setLayout(layoutForIntegerButton);
 
+		this.addOptions(compositeForIntegerButton);
+
 		this.updateStatus();
 		Dialog.applyDialogFont(result);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(this.getControl(), this.getHelpContextID());
+	}
+
+	/**
+	 * A hook for subclasses to add option controls to the page. Called by
+	 * {@link #createControl(Composite)} after the settings have been loaded and the
+	 * option composite has been created. The default implementation does nothing.
+	 * Subclasses override this to call {@link #addIntegerButton} /
+	 * {@link #addBooleanButton} on the given composite.
+	 *
+	 * @param optionComposite The composite to which option controls should be added.
+	 */
+	protected void addOptions(Composite optionComposite) {
+		// Default no-op. Subclasses may override.
 	}
 
 	protected abstract String getDialoGSettingSectionTitle();


### PR DESCRIPTION
Fixes #50.

`InputPage` exposed `addIntegerButton`/`addBooleanButton` helpers and a `createControl` that builds an option composite, but a subclass could not actually add an option control to the page. This PR closes both gaps.

## Changes

- **New `addOptions` extension hook.** Added `protected void addOptions(Composite optionComposite)` with a default no-op body. `createControl` now calls it after `loadSettings()` and after creating the option composite (`compositeForIntegerButton`), passing that composite. Subclasses override it to add controls and reuse the base's settings persistence.
- **Seed-safe button helpers.** Added overloads `addBooleanButton(..., boolean defaultValue, ...)` and `addIntegerButton(..., int defaultValue, ...)` that seed the key into `settings` when absent before reading it, so the helpers work on a fresh dialog-settings section. The original signatures are preserved and delegate with a default (`false` / `0`), keeping downstream callers source-compatible.

With both, a subclass overrides `addOptions`, calls `addIntegerButton`/`addBooleanButton` with a default (e.g. the processor's current value), and reuses the base page machinery instead of duplicating `createControl` + `loadSettings`.

Motivated by ponder-lab/Hybridize-Functions-Refactoring#627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)