### PR TITLE
Add updatesite/category.xml so the eclipse-repository build is non-empty

### DIFF
--- a/edu.cuny.citytech.refactoring.common.updatesite/category.xml
+++ b/edu.cuny.citytech.refactoring.common.updatesite/category.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+  <feature id="edu.cuny.citytech.refactoring.common.feature" version="0.0.0">
+    <category name="edu.cuny.citytech.refactoring.category" />
+  </feature>
+  <category-def name="edu.cuny.citytech.refactoring.category" label="Common Refactoring Framework">
+    <description> A framework with some common functionality for refactoring tool development.
+    </description>
+  </category-def>
+</site>


### PR DESCRIPTION
Extracted from #52 as a standalone, low-risk fix.

Tycho's `eclipse-repository` build was producing an **empty** p2 repo (the README's "Remove the feature and build again" quirk) because the updatesite module only had the legacy `site.xml`. Adding a `category.xml` makes a plain `./mvnw clean install` produce a **complete** per-version p2 repo at `updatesite/target/repository` (feature + 8 bundles + category) — no Eclipse GUI, no p2 publisher, no `-append`.

This benefits the **current** release flow immediately (removes the GUI/quirk dependency) and is a prerequisite for the CI-published flow in #52. `site.xml` and the committed update site are untouched.

Verified: `clean install` produces a populated `target/repository`; `spotless:check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)