### PR TITLE
Exclude category.xml from spotless and match site.xml formatting

### DIFF
--- a/edu.cuny.citytech.refactoring.common.updatesite/category.xml
+++ b/edu.cuny.citytech.refactoring.common.updatesite/category.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-  <feature id="edu.cuny.citytech.refactoring.common.feature" version="0.0.0">
-    <category name="edu.cuny.citytech.refactoring.category" />
-  </feature>
-  <category-def name="edu.cuny.citytech.refactoring.category" label="Common Refactoring Framework">
-    <description> A framework with some common functionality for refactoring tool development.
-    </description>
-  </category-def>
+   <feature id="edu.cuny.citytech.refactoring.common.feature" version="0.0.0">
+      <category name="edu.cuny.citytech.refactoring.category"/>
+   </feature>
+   <category-def name="edu.cuny.citytech.refactoring.category" label="Common Refactoring Framework">
+      <description>
+         A framework with some common functionality for refactoring tool development.
+      </description>
+   </category-def>
 </site>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,7 @@
                   <exclude>**/plugin.xml</exclude>
                   <exclude>**/feature.xml</exclude>
                   <exclude>**/site.xml</exclude>
+                  <exclude>**/category.xml</exclude>
                   <exclude>**/*.target</exclude>
                   <exclude>**/pom.xml</exclude>
                   <exclude>**/dependency-reduced-pom.xml</exclude>


### PR DESCRIPTION
Addresses the review note on #53: the category `<description>` rendered with a leading space because spotless's eclipseWtp XML formatter collapsed it onto one line.

Fix: add `category.xml` to the spotless XML-format excludes (alongside its sibling hand-authored Eclipse descriptors `site.xml`/`feature.xml`/`plugin.xml`), and reformat the description on its own line to match `site.xml`.

Verified: `spotless:check` green and no longer rewrites `category.xml`; `clean install` still produces a populated `target/repository`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)