### PR TITLE
Add `addSpinnerButton` to `InputPage` for bounded integer settings (#56)

### DIFF
--- a/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
+++ b/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
@@ -15,6 +15,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
 
@@ -75,6 +76,41 @@ public abstract class InputPage extends UserInputWizardPage {
 			} catch (@SuppressWarnings("unused") NumberFormatException e) {
 				return;
 			}
+			InputPage.this.settings.put(key, selection);
+			valueConsumer.accept(selection);
+		});
+	}
+
+	/**
+	 * Adds a {@link Spinner} control for a small bounded positive integer setting. Like
+	 * {@link #addIntegerButton(String, String, int, Consumer, Composite)}, this seeds {@code defaultValue} into the dialog settings if
+	 * {@code key} is absent. Unlike the free-text {@link Text}-backed integer button, the spinner offers up/down steppers, enforces
+	 * integer-only input, and pins a {@code minimum}, eliminating the silent parse-failure path.
+	 *
+	 * @param text The label for the control.
+	 * @param key The dialog settings key under which the value is stored.
+	 * @param defaultValue The value seeded into the settings when {@code key} is absent.
+	 * @param minimum The smallest value the spinner allows.
+	 * @param valueConsumer Receives the initial value and each subsequent change.
+	 * @param result The composite to which the control is added.
+	 */
+	protected void addSpinnerButton(String text, String key, int defaultValue, int minimum, Consumer<Integer> valueConsumer,
+			Composite result) {
+		if (this.settings.get(key) == null)
+			this.settings.put(key, defaultValue);
+
+		Label label = new Label(result, SWT.HORIZONTAL);
+		label.setText(text);
+
+		Spinner spinner = new Spinner(result, SWT.BORDER);
+		spinner.setMinimum(minimum);
+		spinner.setSelection(this.settings.getInt(key));
+		// Read back the (possibly minimum-clamped) selection so the consumer and settings stay consistent with the control.
+		int value = spinner.getSelection();
+		this.settings.put(key, value);
+		valueConsumer.accept(value);
+		spinner.addModifyListener(event -> {
+			int selection = ((Spinner) event.widget).getSelection();
 			InputPage.this.settings.put(key, selection);
 			valueConsumer.accept(selection);
 		});


### PR DESCRIPTION
Closes #56.

Adds a sibling `addSpinnerButton` alongside `InputPage.addIntegerButton`:

```java
protected void addSpinnerButton(String text, String key, int defaultValue, int minimum,
        Consumer<Integer> valueConsumer, Composite result)
```

For settings that are small bounded positive integers (e.g. a k-CFA depth), an SWT `Spinner` is a better control than the free-text `Text` field: it offers up/down steppers, enforces integer-only input, and pins a minimum, eliminating the free-text parse-failure path the `Text` listener silently swallows.

## Details

- **Seed-safe** the same way as `addIntegerButton`—seeds `defaultValue` into the dialog settings when `key` is absent.
- **Backed by `Spinner`** with `setMinimum(minimum)`; the `ModifyListener` reads `getSelection()` directly, so there is no `Integer.parseInt`/`NumberFormatException` swallow.
- A stored value **below the minimum** is clamped by the spinner and read back via `getSelection()`, so the consumer and settings stay consistent with the displayed control (handles migration of an existing setting onto a spinner).
- `addIntegerButton` is **retained** for unbounded or free-form integer entry; subclasses choose per field.

## Consumers

- ponder-lab/Hybridize-Functions-Refactoring#627 (PR ponder-lab/Hybridize-Functions-Refactoring#628): k-CFA depth field, minimum 1.
- ponder-lab/Optimize-Java-8-Streams-Refactoring#211: stream-refactoring k-for-streams field, once migrated onto this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)