### PR TITLE
Set an explicit `Spinner` maximum in `addSpinnerButton`

### DIFF
--- a/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
+++ b/edu.cuny.citytech.refactoring.common.ui/src/edu/cuny/citytech/refactoring/common/ui/InputPage.java
@@ -85,7 +85,9 @@ public abstract class InputPage extends UserInputWizardPage {
 	 * Adds a {@link Spinner} control for a small bounded positive integer setting. Like
 	 * {@link #addIntegerButton(String, String, int, Consumer, Composite)}, this seeds {@code defaultValue} into the dialog settings if
 	 * {@code key} is absent. Unlike the free-text {@link Text}-backed integer button, the spinner offers up/down steppers, enforces
-	 * integer-only input, and pins a {@code minimum}, eliminating the silent parse-failure path.
+	 * integer-only input, and pins a {@code minimum}, eliminating the silent parse-failure path. The maximum is left unbounded
+	 * ({@link Integer#MAX_VALUE}) rather than the SWT default of {@code 100}, so stored or default values above {@code 100} are not
+	 * silently clamped.
 	 *
 	 * @param text The label for the control.
 	 * @param key The dialog settings key under which the value is stored.
@@ -103,6 +105,8 @@ public abstract class InputPage extends UserInputWizardPage {
 		label.setText(text);
 
 		Spinner spinner = new Spinner(result, SWT.BORDER);
+		// Raise the cap off SWT's default of 100 before setting the minimum so neither bound silently clamps the stored value.
+		spinner.setMaximum(Integer.MAX_VALUE);
 		spinner.setMinimum(minimum);
 		spinner.setSelection(this.settings.getInt(key));
 		// Read back the (possibly minimum-clamped) selection so the consumer and settings stay consistent with the control.


### PR DESCRIPTION
Follow-up to #57, addressing [this review comment](https://github.com/ponder-lab/Common-Eclipse-Refactoring-Framework/pull/57#discussion_r3453139755).

SWT `Spinner` defaults to a maximum of `100`. `addSpinnerButton` only set a minimum, so any stored or default value above `100` was silently clamped, and a `minimum` above `100` could collapse the allowed range unexpectedly.

This raises the maximum to `Integer.MAX_VALUE` (set before the minimum so neither bound clamps the value), keeping the contract that only a minimum is pinned—the fields this serves (k-CFA depth, etc.) have no natural upper bound. The Javadoc now documents the unbounded maximum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)